### PR TITLE
change install method from exec to vcsrepo

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -10,3 +10,4 @@ project_page 'https://github.com/acme/puppet-acme-oh-my-zsh'
 ## Add dependencies, if any:
 # dependency 'username/name', '>= 1.2.0'
 dependency 'puppetlabs/stdlib'
+dependency 'puppetlabs/vcsrepo'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,31 +26,32 @@
 # Copyright 2013 Leon Brocard
 #
 define ohmyzsh::install() {
-  if $name == 'root' { $home = '/root' } else { $home = "${ohmyzsh::params::home}/${name}" }
-  exec { "ohmyzsh::git clone ${name}":
-    creates => "${home}/.oh-my-zsh",
-    command => "/usr/bin/git clone git://github.com/robbyrussell/oh-my-zsh.git ${home}/.oh-my-zsh",
-    user    => $name,
-    require => [Package['git'], Package['zsh']]
+  if $title == 'root' { $home = '/root' } else { $home = "${ohmyzsh::params::home}/${title}" }
+  vcsrepo { "${home}/.oh-my-zsh":
+    ensure    => present,
+    provider  => git,
+    source    => "git://github.com/robbyrussell/oh-my-zsh.git",
+    user      => $title,
+    require   => [User[$title], Package['zsh']]
   }
 
-  exec { "ohmyzsh::cp .zshrc ${name}":
+  exec { "ohmyzsh::cp .zshrc ${title}":
     creates => "${home}/.zshrc",
     command => "/bin/cp ${home}/.oh-my-zsh/templates/zshrc.zsh-template ${home}/.zshrc",
-    user    => $name,
-    require => Exec["ohmyzsh::git clone ${name}"],
+    user    => $title,
+    require => Vcsrepo["${home}/.oh-my-zsh"],
   }
 
-  if ! defined(User[$name]) {
-    user { "ohmyzsh::user ${name}":
+  if ! defined(User[$title]) {
+    user { "ohmyzsh::user ${title}":
       ensure     => present,
-      name       => $name,
+      name       => $title,
       managehome => true,
       shell      => $ohmyzsh::params::zsh,
       require    => Package['zsh'],
     }
   } else {
-    User <| title == $name |> {
+    User <| title == $title |> {
       shell => $ohmyzsh::params::zsh
     }
   }


### PR DESCRIPTION
exec install method create a loot of problems, and is very difficult to track in debugging, the appropriate method for installing from a GIT repo is using the vcsrepo module.
