### PR TITLE
Fix git clone with unprivileged users

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,7 +31,8 @@ define ohmyzsh::install() {
     creates => "${home}/.oh-my-zsh",
     command => "/usr/bin/git clone git://github.com/robbyrussell/oh-my-zsh.git ${home}/.oh-my-zsh",
     user    => $name,
-    require => [Package['git'], Package['zsh']]
+    require => [Package['git'], Package['zsh']],
+    cwd     => '/tmp',
   }
 
   exec { "ohmyzsh::cp .zshrc ${name}":


### PR DESCRIPTION
Setting a theme on a unprivileged user results in fatal: Could not change back to '/root': Permission denied

Set the current working directory to /tmp so unprivileged users can do a clone.
